### PR TITLE
OT176-59 endpoint creation slides

### DIFF
--- a/controllers/slideController.js
+++ b/controllers/slideController.js
@@ -1,4 +1,5 @@
 const { Slides } = require('../models');
+const awsUpload = require('../utils/awsUpload');
 
 const getSlides = async (req, res, next) => {
   try {
@@ -9,6 +10,24 @@ const getSlides = async (req, res, next) => {
   }
 };
 
+const createSlide = async (req, res, next) => {
+  const { text, organizationId } = req.body;
+  let { order } = req.body;
+  try {
+    if (typeof req.file === 'undefined') throw new Error('Image is required');
+    if (!order) {
+      order = await Slides.max('order') + 1;
+    }
+    const imageUrl = await awsUpload(req.file);
+    const slide = await Slides.create({
+      imageUrl, text, order, organizationId,
+    });
+    res.status(201).json({ slide });
+  } catch (error) {
+    next(error);
+  }
+};
+
 module.exports = {
-  getSlides,
+  getSlides, createSlide,
 };

--- a/routes/slides.js
+++ b/routes/slides.js
@@ -1,10 +1,12 @@
 const express = require('express');
-const { getSlides } = require('../controllers/slideController');
+const { getSlides, createSlide } = require('../controllers/slideController');
 const authenticated = require('../middlewares/authenticated');
 const authAdmin = require('../middlewares/authAdmin');
+const upload = require('../utils/multer');
 
 const router = express.Router();
 
 router.get('/', authenticated, authAdmin, getSlides);
+router.post('/', authenticated, authAdmin, upload('imageUrl'), createSlide);
 
 module.exports = router;

--- a/utils/awsUpload.js
+++ b/utils/awsUpload.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const s3 = require('./s3');
+
+/**
+ * function to upload image in amazon s3
+ * @param {obj} fileImage (req.file of multer)
+ * @returns {string} url final image uploaded
+ */
+const awsUpload = async (fileImage) => {
+  // 1) seteamos los parametros para subir a s3
+  const params = {
+    Bucket: process.env.AWS_BUCKET_NAME,
+    Key: uuidv4() + path.extname(fileImage.originalname),
+    Body: fileImage.buffer,
+    ACL: 'public-read',
+    ContentEncoding: 'base64',
+    ContentDisposition: 'inline',
+    ContentType: 'image/jpeg',
+  };
+  try {
+    // 2) espero hasta subir la imagen y devuelvo la url
+    const storedFile = await s3.upload(params).promise();
+    return storedFile?.Location;
+  } catch (err) {
+    throw new Error(err.message);
+  }
+};
+
+module.exports = awsUpload;

--- a/utils/multer.js
+++ b/utils/multer.js
@@ -1,4 +1,5 @@
 const multer = require('multer');
+const path = require('path');
 
 const storage = multer.memoryStorage({
   destination(req, file, callback) {
@@ -6,6 +7,17 @@ const storage = multer.memoryStorage({
   },
 });
 
-const upload = multer({ storage }).single('image');
+// const limits = { fileSize: 1024 * 1024 * 10 };
+const fileFilter = (req, file, callback) => {
+  const filetypes = /jpeg|jpg|png/;
+  const extname = filetypes.test(path.extname(file.originalname).toLowerCase());
+  const mimetype = filetypes.test(file.mimetype);
+  if (!mimetype && !extname) {
+    return callback(new Error('Error: Allow images only of extensions jpeg|jpg|png !'), false);
+  }
+  return callback(null, true);
+};
+
+const upload = (input = 'image') => multer({ storage, fileFilter }).single(input);
 
 module.exports = upload;


### PR DESCRIPTION
### SUMMARY
- Add function to create new slide
- Add route endpoint POST/slides
- Update function utils/multer.js to filter type of images allowed and also allow a different field name
```js 
// in middlewares, use of multer

// .., upload(), ..controller
upload() // -> for default name field "image"

// .., upload("imageUrl"), ..controller
upload("imageUrl") // -> name field "imageUrl"

```
- Add new function to upload images in aws from controllers
```js 
// in any controllers with req.file
const newImage = await awsUpload(req.file)
// newImage will contain the final url when the image is uploaded to aws
```